### PR TITLE
Update GeminiClient.php

### DIFF
--- a/src/Client/GeminiClient.php
+++ b/src/Client/GeminiClient.php
@@ -81,7 +81,7 @@ class GeminiClient
 
             return json_decode($response->getBody(), true);
         } catch (RequestException $e) {
-            if ($e->getResponse()->getStatusCode() == 404) {
+            if (!$e->getResponse() || $e->getResponse()->getStatusCode() == 404) {
                 return null;
             }
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1467

# What does this Pull Request do?

Extra null check to avoid a WSOD when Gemini is down

# How should this be tested?

Easiest way is to misconfigure Islandora to point to a non-existing Gemini.  You can't do it in the form (we validate!), but you can do it with Drush

`drush cset -y --input-format=yaml islandora.settings gemini_url http://totallynotasite:8000/gemini`

Then view some content and you should get a whitescreen.

After applying this PR, you should be able to view some content without whitescreen.

Be sure to put your Gemini back:

`drush cset -y --input-format=yaml islandora.settings gemini_url http://localhost:8000/gemini`

# Interested parties
@Islandora/8-x-committers
